### PR TITLE
add a default max alive time parameter to override situation when it …

### DIFF
--- a/src/main/java/com/crimsonhexagon/rsm/RedisSessionManager.java
+++ b/src/main/java/com/crimsonhexagon/rsm/RedisSessionManager.java
@@ -266,7 +266,10 @@ public abstract class RedisSessionManager extends ManagerBase {
 		}
 
 		log.trace("Setting expire on " + redisSession.getId() + " to " + getSessionMaxAliveTime());
-		client.expire(sessionKey, getSessionMaxAliveTime(), TimeUnit.SECONDS);
+		int maxAliveTime = getSessionMaxAliveTime();
+		maxAliveTime = (maxAliveTime != 0) ? maxAliveTime : DEFAULT_MAX_ALIVE_TIME;
+		
+		client.expire(sessionKey,  maxAliveTime, TimeUnit.SECONDS);
 	}
 
 	@Override


### PR DESCRIPTION
…is 0 - making all sessions expire immediatley