### PR TITLE
Fix issue #12 - set new to false on session load from Redis store

### DIFF
--- a/src/main/java/com/crimsonhexagon/rsm/RedisSessionManager.java
+++ b/src/main/java/com/crimsonhexagon/rsm/RedisSessionManager.java
@@ -242,6 +242,7 @@ public abstract class RedisSessionManager extends ManagerBase {
 			if (session != null) {
 				log.debug("Found session " + id + " in redis");
 				session.postDeserialization(this);
+				session.setNew(false); // Fix issue #12
 				currentSessionState.set(new RedisSessionState(session, true));
 			} else {
 				log.debug("Session " + id + " not found in redis");


### PR DESCRIPTION
There are no tests to fix, and it's not trivial to mock all the stuff to test this fix, but based on my testing this works to mark a session not new when it's loaded from Redis.