### PR TITLE
Support Tomcat Form Authentication

### DIFF
--- a/src/main/java/com/crimsonhexagon/rsm/note/SavedRequestConverter.java
+++ b/src/main/java/com/crimsonhexagon/rsm/note/SavedRequestConverter.java
@@ -1,0 +1,102 @@
+/*-
+ *  Copyright 2015 Crimson Hexagon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.crimsonhexagon.rsm.note;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.servlet.http.Cookie;
+
+import org.apache.catalina.authenticator.SavedRequest;
+import org.apache.tomcat.util.buf.ByteChunk;
+
+/**
+ * Converts tomcat non-serializable SavedRequest to a serializable
+ * version.
+ *
+ * @author Adrian
+ */
+public class SavedRequestConverter implements Function<Object, Object> {
+
+    @Override
+    public Object apply(Object o) {
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof SavedRequest) {
+            return new SerializableSavedRequest((SavedRequest) o);
+        }
+        if (o instanceof SerializableSavedRequest) {
+            return ((SerializableSavedRequest) o).toSavedRequest();
+        }
+        throw new IllegalArgumentException ("Cannot convert instance of type " + o.getClass().getName());
+    }
+
+    public static class SerializableSavedRequest implements Serializable {
+
+        private static final long serialVersionUID = 6668024035102051230L;
+
+        private List<Cookie> cookies = new ArrayList<>();
+        private Map<String, List<String>> headers = new HashMap<>();
+        private List<Locale> locales = new ArrayList<>();
+        private ByteChunk body;
+        private String contentType;
+        private String decodedRequestURI;
+        private String requestURI;
+        private String method;
+        private String queryString;
+
+        public SerializableSavedRequest(SavedRequest savedRequest) {
+            Iterator<String> headerNames = savedRequest.getHeaderNames();
+            while (headerNames.hasNext()) {
+                String name = headerNames.next();
+                List<String> values = new ArrayList<>();
+                savedRequest.getHeaderValues(name).forEachRemaining(values::add);
+                this.headers.put(name, values);
+            }
+            savedRequest.getLocales().forEachRemaining(this.locales::add);
+            this.body = savedRequest.getBody();
+            this.contentType = savedRequest.getContentType();
+            this.decodedRequestURI = savedRequest.getDecodedRequestURI();
+            this.requestURI = savedRequest.getRequestURI();
+            this.method = savedRequest.getMethod();
+            this.queryString = savedRequest.getQueryString();
+            savedRequest.getCookies().forEachRemaining(cookies::add);
+        }
+
+        public SavedRequest toSavedRequest() {
+            SavedRequest savedRequest = new SavedRequest();
+            cookies.stream().forEach(savedRequest::addCookie);
+            headers.forEach((name, values) -> {
+                values.forEach(value -> savedRequest.addHeader(name, value));
+            });
+            locales.forEach(savedRequest::addLocale);
+            savedRequest.setBody(body);
+            savedRequest.setContentType(contentType);
+            savedRequest.setDecodedRequestURI(decodedRequestURI);
+            savedRequest.setRequestURI(requestURI);
+            savedRequest.setMethod(method);
+            savedRequest.setQueryString(queryString);
+            return savedRequest;
+        }
+    }
+}

--- a/src/test/java/com/crimsonhexagon/rsm/RedisSessionTest.java
+++ b/src/test/java/com/crimsonhexagon/rsm/RedisSessionTest.java
@@ -3,15 +3,29 @@ package com.crimsonhexagon.rsm;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.authenticator.Constants;
+import org.apache.catalina.authenticator.SavedRequest;
+import org.apache.catalina.connector.CoyotePrincipal;
+import org.apache.catalina.session.StandardSession;
+import org.apache.catalina.users.MemoryUser;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class RedisSessionTest {
+
+	private RedisSessionManager mgr = mock(RedisSessionManager.class);
 
 	@Test
 	public void testNewAttribute() {
@@ -60,7 +74,7 @@ public class RedisSessionTest {
 			rs.clearDirty();
 			l.add("bar");
 			rs.setAttribute("strList", l);
-			Assert.assertTrue(rs.isDirty());			
+			Assert.assertTrue(rs.isDirty());
 		}
 		
 	}
@@ -79,10 +93,88 @@ public class RedisSessionTest {
 		rs.removeAttribute("foo");
 		Assert.assertTrue(rs.isDirty());
 	}
-	
+
+	@Test
+	public void testSerializedTransientFields() {
+		RedisSession rs = session();
+		rs.setAttribute("foo", "bar");
+		Principal principal = new CoyotePrincipal("user");
+		rs.setPrincipal(principal);
+		byte[] serializedState = serialize(rs);
+		RedisSession result = deserialize(serializedState);
+		Assert.assertNotNull(result.getPrincipal());
+		Assert.assertEquals(principal.getName(), result.getPrincipal().getName());
+		Assert.assertNotNull(getFieldValue(result,"support"));
+		Assert.assertNotNull(getFieldValue(result,"listeners"));
+		Assert.assertNotNull(getFieldValue(result,"notes"));
+	}
+
+	@Test
+	public void testFormRequestNoteSerialization() {
+		RedisSession rs = session();
+		SavedRequest savedRequest = new SavedRequest();
+		savedRequest.setRequestURI("http://someuri");
+		rs.setNote(Constants.FORM_REQUEST_NOTE, savedRequest);
+		rs = deserialize(serialize(rs));
+		SavedRequest result = (SavedRequest) rs.getNote(Constants.FORM_REQUEST_NOTE);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(savedRequest.getRequestURI(), result.getRequestURI());
+	}
+
+	@Test
+	public void testFormPrincipalNoteSerialization() {
+		RedisSession rs = session();
+		Principal principal = new CoyotePrincipal("user");
+		rs.setNote(Constants.FORM_PRINCIPAL_NOTE, principal);
+		rs = deserialize(serialize(rs));
+		Principal result = (Principal) rs.getNote(Constants.FORM_PRINCIPAL_NOTE);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(principal.getName(), result.getName());
+	}
+
+	@Test
+	public void testUnknownNoteSerialization() {
+		RedisSession rs = session();
+		rs.setNote("unknown", "someValue");
+		rs = deserialize(serialize(rs));
+		Assert.assertNull(rs.getNote("unknown"));
+	}
+
+	private Object getFieldValue(Object object, String name) {
+		Field field = null;
+		try {
+			field = StandardSession.class.getDeclaredField(name);
+			field.setAccessible(true);
+			return field.get(object);
+		} catch (NoSuchFieldException|IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private byte[] serialize(RedisSession session) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try(ObjectOutputStream stream = new ObjectOutputStream(baos)) {
+			stream.writeObject(session);
+			stream.flush();
+			return baos.toByteArray();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private RedisSession deserialize(byte[] state) {
+		ByteArrayInputStream baos = new ByteArrayInputStream(state);
+		try (ObjectInputStream stream = new ObjectInputStream(baos)){
+			RedisSession redisSession = (RedisSession) stream.readObject();
+			redisSession.postDeserialization(mgr);
+			return redisSession;
+		} catch (IOException|ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	private RedisSession session() {
 		RedisSession rs = new RedisSession();
-		RedisSessionManager mgr = mock(RedisSessionManager.class);
 		when(mgr.isDirtyOnMutation()).thenCallRealMethod();
 		Mockito.doCallRealMethod().when(mgr).setDirtyOnMutation(Mockito.anyBoolean());
 		when(mgr.isForceSaveAfterRequest()).thenCallRealMethod();

--- a/src/test/java/com/crimsonhexagon/rsm/note/SavedRequestConverterTest.java
+++ b/src/test/java/com/crimsonhexagon/rsm/note/SavedRequestConverterTest.java
@@ -1,0 +1,85 @@
+/*-
+ *  Copyright 2015 Crimson Hexagon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.crimsonhexagon.rsm.note;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import javax.servlet.http.Cookie;
+
+import org.apache.catalina.authenticator.SavedRequest;
+import org.apache.tomcat.util.buf.ByteChunk;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SavedRequestConverterTest {
+
+    private SavedRequestConverter converter = new SavedRequestConverter();
+
+    @Test
+    public void testConversion() throws IOException {
+        SavedRequest savedRequest = new SavedRequest();
+        savedRequest.setRequestURI("http://someuri");
+        savedRequest.setQueryString("queryString");
+        savedRequest.setMethod("GET");
+        savedRequest.setDecodedRequestURI("http://decodeduri");
+        savedRequest.setContentType("text/html");
+        ByteChunk body = new ByteChunk();
+        body.append((byte) 5);
+        savedRequest.setBody(body);
+        savedRequest.addHeader("Accept", "text/html");
+        savedRequest.addHeader("Accept", "text/xml");
+        savedRequest.addCookie(new Cookie("name", "value"));
+        savedRequest.addLocale(Locale.GERMAN);
+        SavedRequestConverter.SerializableSavedRequest serializableRequest =
+                (SavedRequestConverter.SerializableSavedRequest) converter.apply(savedRequest);
+        SavedRequest result = serializableRequest.toSavedRequest();
+        Assert.assertEquals(savedRequest.getRequestURI(), result.getRequestURI());
+        Assert.assertEquals(savedRequest.getBody(), result.getBody());
+        Assert.assertEquals(savedRequest.getContentType(), result.getContentType());
+        List<Cookie> cookies = new ArrayList<>();
+        Assert.assertEquals(toList(savedRequest.getCookies()), toList(result.getCookies()));
+        Assert.assertEquals(savedRequest.getDecodedRequestURI(), result.getDecodedRequestURI());
+        Assert.assertEquals(toList(savedRequest.getHeaderNames()), toList(result.getHeaderNames()));
+        Assert.assertEquals(toList(savedRequest.getHeaderValues("Accept")),
+                toList(result.getHeaderValues("Accept")));
+        Assert.assertEquals(toList(savedRequest.getLocales()), toList(result.getLocales()));
+        Assert.assertEquals(savedRequest.getMethod(), result.getMethod());
+        Assert.assertEquals(savedRequest.getQueryString(), result.getQueryString());
+    }
+
+    @Test
+    public void testNullValue() {
+        Assert.assertNull(converter.apply(null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidClass() {
+        converter.apply("invalidClass");
+    }
+
+    private <E> List<E> toList(Iterator<E> iterator) {
+        List<E> list = new ArrayList<>();
+        iterator.forEachRemaining(list::add);
+        return list;
+    }
+}


### PR DESCRIPTION
PR for #14 

Fixes to support tomcat form-based authentication
relying on transient fields (ie. session#notes).

This PR is pretty intrusive in respect to Tomcat Session class which declares some fields as transient (while they should be stored in Redis to support clustering).