### PR TITLE
Update versions dependences and change update method SerializationCodec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
 		<dependency>
 			<groupId>org.redisson</groupId>
 			<artifactId>redisson</artifactId>
-			<version>3.5.1</version>
+			<version>3.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-transport-native-epoll</artifactId>
-			<version>4.1.13.Final</version>
+			<version>4.1.17.Final</version>
 			<classifier>linux-x86_64</classifier>
 		</dependency>
 		<dependency>
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.apache.tomcat</groupId>
 			<artifactId>tomcat-catalina</artifactId>
-			<version>8.0.39</version>
+			<version>8.5.8</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/crimsonhexagon/rsm/redisson/RedissonSessionClient.java
+++ b/src/main/java/com/crimsonhexagon/rsm/redisson/RedissonSessionClient.java
@@ -86,7 +86,7 @@ public class RedissonSessionClient implements RedisSessionClient {
 	@Override
     public int getEncodedSize(Object obj) {
 	    try {
-            return redissonClient.getConfig().getCodec().getValueEncoder().encode(obj).length;
+            return redissonClient.getConfig().getCodec().getValueEncoder().encode(obj).capacity();
         } catch (IOException e) {
             throw new IllegalArgumentException(e); // redisson style
         }

--- a/src/test/java/com/crimsonhexagon/rsm/MockRedisSessionClient.java
+++ b/src/test/java/com/crimsonhexagon/rsm/MockRedisSessionClient.java
@@ -55,7 +55,7 @@ public class MockRedisSessionClient implements RedisSessionClient {
     @Override
     public int getEncodedSize(Object obj) {
         try {
-            return codec.getValueEncoder().encode(obj).length;
+            return codec.getValueEncoder().encode(obj).capacity();
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }


### PR DESCRIPTION
redisson 3.5.1 -> 3.5.5 and change attribute length SerializationCodec for new method capacity on ByteBuf;
netty epoll 4.1.13.Final -> 4.1.17.Final;
tomcat 8.0.39 -> 8.5.8;